### PR TITLE
Fix printk format for 64-bit computers (size_t was hardcoded to %u)

### DIFF
--- a/acpi_call.c
+++ b/acpi_call.c
@@ -304,7 +304,7 @@ static int acpi_proc_write( struct file *filp, const char __user *buff,
 
     if (len > sizeof(input) - 1) {
 #ifdef HAVE_PROC_CREATE
-        printk(KERN_ERR "acpi_call: Input too long! (%u)\n", len);
+        printk(KERN_ERR "acpi_call: Input too long! (%zu)\n", len);
 #else
         printk(KERN_ERR "acpi_call: Input too long! (%lu)\n", len);
 #endif


### PR DESCRIPTION
this should fix `%lu` vs `%u` warning in new kernels for 64bit linux, without reintroducing warning for older kernels