### PR TITLE
Allow dkms.conf to be used outside of the repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ MANIFEST
 Module.symvers
 debian/tmp/*
 modules.order
+dkms.conf

--- a/Makefile
+++ b/Makefile
@@ -17,16 +17,19 @@ load:
 	-/sbin/rmmod acpi_call
 	/sbin/insmod acpi_call.ko
 
-dkms-add:
+dkms.conf: dkms.conf.in
+	sed "s/@@VERSION@@/$(VERSION)/" $^ > $@
+
+dkms-add: dkms.conf
 	/usr/sbin/dkms add $(CURDIR)
 
-dkms-build:
+dkms-build: dkms.conf
 	/usr/sbin/dkms build acpi_call/$(VERSION)
 
-dkms-install:
+dkms-install: dkms.conf
 	/usr/sbin/dkms install acpi_call/$(VERSION)
 
-dkms-remove:
+dkms-remove: dkms.conf
 	/usr/sbin/dkms remove acpi_call/$(VERSION) --all
 
 modprobe-install:

--- a/dkms.conf.in
+++ b/dkms.conf.in
@@ -1,5 +1,5 @@
 PACKAGE_NAME="acpi_call"
-PACKAGE_VERSION="$(cat VERSION)"
+PACKAGE_VERSION="@@VERSION@@"
 MAKE="KDIR=/lib/modules/${kernelver}/build make"
 CLEAN="make clean"
 BUILT_MODULE_NAME[0]="acpi_call"


### PR DESCRIPTION
Add a Makefile target that turns the dkms.conf.in template into a
dkms.conf file that has all the necessary informantion to be installed
directly on a system.