### PR TITLE
turn_off_gpu.sh: Add acpi_string for Legion R7000

### DIFF
--- a/examples/turn_off_gpu.sh
+++ b/examples/turn_off_gpu.sh
@@ -33,6 +33,7 @@ methods="
 \_SB.PCI0.PEG0.PEGP.SGOF
 \_SB.PCI0.AGP.VGA.PX02
 \_SB.PCI0.RP05.PXSX._OFF
+\_SB.PCI0.GPP0.PG00._OFF
 "
 
 for m in $methods; do


### PR DESCRIPTION
Add acpi_string for Lenovo Legion 5 15ARH05H (aka. Legion R7000). 
GPU: NVIDIA 01:00.0 NVIDIA Corporation TU117M (GTX1650)
GPU: AMD ATI 06:00.0 Renoir (vega 7)
Other laptop with similar GPU also work (eg. ASUS Zephyrus G14).