### PR TITLE
turn_off_gpu.sh: add acpi method for RTX A1000

### DIFF
--- a/examples/turn_off_gpu.sh
+++ b/examples/turn_off_gpu.sh
@@ -34,6 +34,7 @@ methods="
 \_SB.PCI0.AGP.VGA.PX02
 \_SB.PCI0.RP05.PXSX._OFF
 \_SB.PCI0.GPP0.PG00._OFF
+\_SB_.PC00.PEG1.PEGP._PS3
 "
 
 for m in $methods; do


### PR DESCRIPTION
I see that https://github.com/mkottman/acpi_call isn't really making changes these days, but this fork is. So I'm making a PR here, too.

I've come into possession of a Dell Precision 5570 and found the right acpi method call to disable its GPU, and so I've added that to this script.

---

For those interested, here's the process I used to find the method call (might be useful to others in the future): https://github.com/acheronfail/acpi_call_finder