### PR TITLE
Added ACPI method for ThinkPad E490 GPU turn off

### DIFF
--- a/examples/turn_off_gpu.sh
+++ b/examples/turn_off_gpu.sh
@@ -35,6 +35,7 @@ methods="
 \_SB.PCI0.RP05.PXSX._OFF
 \_SB.PCI0.GPP0.PG00._OFF
 \_SB_.PC00.PEG1.PEGP._PS3
+\_SB_.PCI0.RP05.PEGP._OFF
 "
 
 for m in $methods; do


### PR DESCRIPTION
Added ACPI method "\\\_SB_.PCI0.RP05.PEGP._OFF" to the script "turn_off_gpu.sh". That method successfully turns off the discrete AMD GPU of a Lenovo ThinkPad E490.

After turning off, discharge rate reported by powertop is about 4W lower.

GPU remains off after resuming from sleep.